### PR TITLE
fix: electron community mode detection and project creation FK constraint

### DIFF
--- a/ygg-chat/client/ygg-chat-r/electron/headlessServer/routes/appAutomationRoutes.ts
+++ b/ygg-chat/client/ygg-chat-r/electron/headlessServer/routes/appAutomationRoutes.ts
@@ -394,6 +394,16 @@ export function registerAppAutomationRoutes(app: Express, deps: AppAutomationRou
         return
       }
 
+      // Ensure user exists before creating project (FK constraint)
+      const existingUser = db.prepare('SELECT id FROM users WHERE id = ?').get(user_id)
+      if (!existingUser) {
+        db.prepare('INSERT INTO users (id, username, created_at) VALUES (?, ?, ?)').run(
+          user_id,
+          `local-user-${user_id.substring(0, 8)}`,
+          new Date().toISOString()
+        )
+      }
+
       const projectId = id || uuidv4()
       const now = new Date().toISOString()
 

--- a/ygg-chat/client/ygg-chat-r/src/features/conversations/conversationActions.ts
+++ b/ygg-chat/client/ygg-chat-r/src/features/conversations/conversationActions.ts
@@ -2,7 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import type { ConversationId, ProjectId } from '../../../../../shared/types'
 import { RootState } from '../../store/store'
 import { ThunkExtraArgument } from '../../store/thunkExtra'
-import { isCommunityMode } from '../../config/runtimeMode'
+import { isCommunityMode, isElectronMode } from '../../config/runtimeMode'
 import {
   api,
   localApi,
@@ -20,7 +20,7 @@ import { convContextSet, systemPromptSet } from './conversationSlice'
 import { Conversation } from './conversationTypes'
 import { dualSync } from '../../lib/sync/dualSyncManager'
 
-const isElectronCommunityMode = () => environment === 'electron' && isCommunityMode
+const isElectronCommunityMode = () => isElectronMode && isCommunityMode
 
 // Fetch conversations for current user
 // Note: fetchRecentModels has been migrated to React Query (see useRecentModels in hooks/useQueries.ts)

--- a/ygg-chat/client/ygg-chat-r/src/features/projects/projectActions.ts
+++ b/ygg-chat/client/ygg-chat-r/src/features/projects/projectActions.ts
@@ -1,12 +1,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import { Project, StorageMode } from '../../../../../shared/types'
-import { isCommunityMode } from '../../config/runtimeMode'
+import { isCommunityMode, isElectronMode } from '../../config/runtimeMode'
 import { apiCall, localApi, environment, shouldUseLocalApi } from '../../utils/api'
 import { ThunkExtraArgument } from '../../store/thunkExtra'
 import { RootState } from '../../store/store'
 import { dualSync } from '../../lib/sync/dualSyncManager'
 
-const isElectronCommunityMode = () => environment === 'electron' && isCommunityMode
+const isElectronCommunityMode = () => isElectronMode && isCommunityMode
 
 // Fetch all projects
 export const fetchProjects = createAsyncThunk<Project[], void, { extra: ThunkExtraArgument }>(

--- a/ygg-chat/client/ygg-chat-r/src/hooks/useQueries.ts
+++ b/ygg-chat/client/ygg-chat-r/src/hooks/useQueries.ts
@@ -18,12 +18,12 @@ import type { Message, Model } from '../features/chats/chatTypes'
 import { fetchLmStudioModels } from '../features/chats/LMStudio'
 import { getOpenAIChatGPTModels } from '../features/chats/openaiOAuth'
 import type { Conversation } from '../features/conversations/conversationTypes'
-import { isCommunityMode } from '../config/runtimeMode'
+import { isCommunityMode, isElectronMode } from '../config/runtimeMode'
 import { api, environment, localApi } from '../utils/api'
 import { getFavoritedModels } from '../utils/favorites'
 import { useAuth } from './useAuth'
 
-const isElectronCommunityMode = () => environment === 'electron' && isCommunityMode
+const isElectronCommunityMode = () => isElectronMode && isCommunityMode
 
 /**
  * Fetch all projects for the current user, sorted by latest conversation


### PR DESCRIPTION
## Summary
- **Community mode detection**: `useQueries.ts`, `projectActions.ts`, and `conversationActions.ts` used `environment === 'electron'` (from `VITE_ENVIRONMENT` env var) to detect Electron community mode. When `.env` is missing, this silently defaults to `'local'`, causing all data fetching to hit the cloud API with a fake token. Fixed by using `isElectronMode` from `runtimeMode.ts`, which relies on the build-time `__IS_ELECTRON__` constant and is always correct.
- **FK constraint on project creation**: The headless server's `POST /api/app/projects` route inserted a project with a `user_id` foreign key without ensuring the user row existed first. This caused `SQLITE_CONSTRAINT_FOREIGNKEY` errors on first launch in local mode. Added user auto-creation before project insert, matching what `localServer.ts` sync routes already do.

## Test plan
- [ ] Build the Electron app without a `.env` file (`npm run build:mac`)
- [ ] Launch and click "Continue in Local Mode"
- [ ] Verify the app navigates past the login page to a chat
- [ ] Verify no `FOREIGN KEY constraint failed` errors in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)