### PR TITLE
Removed the Settings page’s Global Agent configuration section.

### DIFF
--- a/ygg-chat/client/ygg-chat-r/src/containers/Settings.tsx
+++ b/ygg-chat/client/ygg-chat-r/src/containers/Settings.tsx
@@ -26,12 +26,6 @@ import {
 } from '../features/chats/openaiOAuth'
 import { getAllTools } from '../features/chats/toolDefinitions'
 import {
-  AGENT_SETTINGS_CHANGE_EVENT,
-  AgentSettings,
-  loadAgentSettings,
-  saveAgentSettings,
-} from '../helpers/agentSettingsStorage'
-import {
   CHAT_REASONING_SETTINGS_CHANGE_EVENT,
   ChatReasoningSettings,
   loadChatReasoningSettings,
@@ -211,7 +205,6 @@ const Settings: React.FC = () => {
   const tools = getAllTools()
   const [toolsExpanded, setToolsExpanded] = useState(false)
   const [htmlToolsExpanded, setHtmlToolsExpanded] = useState(false)
-  const [agentToolsExpanded, setAgentToolsExpanded] = useState(false)
   const [updatingTools, setUpdatingTools] = useState<Set<string>>(new Set())
   const [reloadingTools, setReloadingTools] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -303,22 +296,6 @@ const Settings: React.FC = () => {
     loadHeimdallNotePreviewHoverPaddingEnabled()
   )
   const [browserSettings, setBrowserSettings] = useState<BrowserSettings>(() => loadBrowserSettings())
-  const [agentSettings, setAgentSettings] = useState<AgentSettings>({
-    heartbeatTime: null,
-    agentName: 'Global Agent',
-    model: null,
-    modelContextLength: null,
-    loopIntervalMs: 60000,
-    autoResume: true,
-    toolAllowlist: null,
-    workDirectory: null,
-  })
-  const [workDirectoryInput, setWorkDirectoryInput] = useState('')
-  const [workDirectoryTouched, setWorkDirectoryTouched] = useState(false)
-  const [loopIntervalInput, setLoopIntervalInput] = useState('60000')
-  const [loopIntervalTouched, setLoopIntervalTouched] = useState(false)
-  const [agentSettingsLoading, setAgentSettingsLoading] = useState(true)
-  const [agentSettingsSaving, setAgentSettingsSaving] = useState(false)
   const [subagentSettings, setSubagentSettings] = useState<SubagentToolSettings>(() => loadSubagentToolSettings())
   const [subagentMaxTurnsInput, setSubagentMaxTurnsInput] = useState<string>(() =>
     String(loadSubagentToolSettings().maxTurns)
@@ -328,7 +305,6 @@ const Settings: React.FC = () => {
     loadHermesRuntimeSettings()
   )
   const [electronPlatform, setElectronPlatform] = useState<string>('')
-  const { data: openRouterModelsData } = useModels('OpenRouter')
   const compactionProviderForModels = providerSettings.compactionProvider || providers.currentProvider || 'OpenRouter'
   const { data: compactionModelsData } = useModels(compactionProviderForModels)
   const normalizedRemoteBaseUrlInput = normalizeRemoteBaseUrl(remoteBaseUrlInput)
@@ -337,10 +313,8 @@ const Settings: React.FC = () => {
   const remoteQrCodeImageUrl = effectiveRemoteMobileUrl
     ? `https://api.qrserver.com/v1/create-qr-code/?size=220x220&data=${encodeURIComponent(effectiveRemoteMobileUrl)}`
     : null
-  const subagentDefaultModelPreview =
-    typeof agentSettings.model === 'string' && agentSettings.model.trim().length > 0
-      ? agentSettings.model.trim()
-      : 'openai/gpt-5.3-codex'
+  const subagentProviderForModels = subagentSettings.defaultProvider || providers.currentProvider || 'OpenRouter'
+  const { data: subagentModelsData } = useModels(subagentProviderForModels)
   const defaultChatModePrompt = getDefaultChatModePrompt()
   const selectedChatModePrompt =
     operationModePromptSettings.selectedChatPromptId === DEFAULT_CHAT_MODE_PROMPT_ID
@@ -1441,27 +1415,28 @@ const Settings: React.FC = () => {
     )
   }
 
-  const handleSubagentForceOpenAIToggle = () => {
+  const handleSubagentProviderChange = (providerName: string) => {
+    const nextProvider = providerName || null
     persistSubagentSettings(
       {
         ...subagentSettings,
-        forceOpenAIProviderWhenChatGPTSelected: !subagentSettings.forceOpenAIProviderWhenChatGPTSelected,
+        defaultProvider: nextProvider,
+        defaultModel: null,
       },
-      !subagentSettings.forceOpenAIProviderWhenChatGPTSelected
-        ? 'Subagent now forces OpenAI provider when chat provider is OpenAI (ChatGPT).'
-        : 'Subagent no longer forces OpenAI provider from chat provider state.'
+      nextProvider
+        ? `Subagent provider set to "${nextProvider}".`
+        : 'Subagent provider will follow the current chat provider.'
     )
   }
 
-  const handleSubagentUseGlobalModelToggle = () => {
+  const handleSubagentModelChange = (modelName: string) => {
+    const nextModel = modelName || null
     persistSubagentSettings(
       {
         ...subagentSettings,
-        useGlobalAgentModelAsDefault: !subagentSettings.useGlobalAgentModelAsDefault,
+        defaultModel: nextModel,
       },
-      !subagentSettings.useGlobalAgentModelAsDefault
-        ? 'Subagent now defaults to Global Agent model when tool call omits model.'
-        : 'Subagent will no longer default to Global Agent model when model is omitted.'
+      nextModel ? 'Subagent model updated.' : 'Subagent model will use provider selected/default model.'
     )
   }
 
@@ -1839,68 +1814,6 @@ const Settings: React.FC = () => {
   }
 
   useEffect(() => {
-    if (import.meta.env.VITE_ENVIRONMENT !== 'electron') {
-      setAgentSettingsLoading(false)
-      return
-    }
-
-    let isActive = true
-
-    loadAgentSettings()
-      .then(settings => {
-        if (!isActive) return
-        setAgentSettings(settings)
-      })
-      .catch(error => {
-        console.error('Failed to load agent settings:', error)
-        if (isActive) {
-          showStatus({ type: 'error', text: 'Failed to load global agent settings.' })
-        }
-      })
-      .finally(() => {
-        if (isActive) {
-          setAgentSettingsLoading(false)
-        }
-      })
-
-    const handleAgentSettingsChange = (e: CustomEvent<AgentSettings>) => {
-      if (!isActive) return
-      setAgentSettings(e.detail)
-    }
-
-    window.addEventListener(AGENT_SETTINGS_CHANGE_EVENT, handleAgentSettingsChange as EventListener)
-    return () => {
-      isActive = false
-      window.removeEventListener(AGENT_SETTINGS_CHANGE_EVENT, handleAgentSettingsChange as EventListener)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (agentSettingsLoading || import.meta.env.VITE_ENVIRONMENT !== 'electron') return
-    if (agentSettings.toolAllowlist && agentSettings.toolAllowlist.length > 0) return
-
-    const defaultAllowlist = tools.filter(tool => tool.enabled || tool.name === 'bash').map(tool => tool.name)
-
-    if (defaultAllowlist.length === 0) return
-
-    const nextSettings = { ...agentSettings, toolAllowlist: defaultAllowlist }
-    setAgentSettings(nextSettings)
-    saveAgentSettings(nextSettings).catch(error => {
-      console.error('Failed to persist default global agent tools:', error)
-    })
-  }, [agentSettings, agentSettingsLoading, tools])
-
-  useEffect(() => {
-    if (workDirectoryTouched) return
-    setWorkDirectoryInput(agentSettings.workDirectory ?? '')
-  }, [agentSettings.workDirectory, workDirectoryTouched])
-
-  useEffect(() => {
-    if (loopIntervalTouched) return
-    setLoopIntervalInput(String(agentSettings.loopIntervalMs ?? 60000))
-  }, [agentSettings.loopIntervalMs, loopIntervalTouched])
-
-  useEffect(() => {
     if (toolCallTimeoutTouched) return
     setToolCallTimeoutInput(String(toolExecutionSettings.toolCallTimeoutMs))
   }, [toolExecutionSettings.toolCallTimeoutMs, toolCallTimeoutTouched])
@@ -1928,67 +1841,6 @@ const Settings: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [isChangelogOpen])
 
-  const persistAgentSettings = async (nextSettings: AgentSettings, successText: string, errorText: string) => {
-    setAgentSettings(nextSettings)
-
-    if (import.meta.env.VITE_ENVIRONMENT !== 'electron') {
-      return
-    }
-
-    setAgentSettingsSaving(true)
-    try {
-      const saved = await saveAgentSettings(nextSettings)
-      setAgentSettings(saved)
-      showStatus({ type: 'success', text: successText })
-    } catch (error) {
-      console.error('Failed to save agent settings:', error)
-      showStatus({ type: 'error', text: errorText })
-      try {
-        const refreshed = await loadAgentSettings()
-        setAgentSettings(refreshed)
-      } catch (refreshError) {
-        console.error('Failed to reload agent settings:', refreshError)
-      }
-    } finally {
-      setAgentSettingsSaving(false)
-    }
-  }
-
-  const handleHeartbeatTimeChange = async (value: string) => {
-    const nextHeartbeat = value.trim().length > 0 ? value : null
-    const nextSettings = { ...agentSettings, heartbeatTime: nextHeartbeat }
-    await persistAgentSettings(
-      nextSettings,
-      nextHeartbeat ? 'Heartbeat time updated.' : 'Heartbeat disabled.',
-      'Failed to update heartbeat time.'
-    )
-  }
-
-  const handleAgentNameChange = async (value: string) => {
-    const nextName = value.trim().length > 0 ? value.trim() : 'Global Agent'
-    await persistAgentSettings(
-      { ...agentSettings, agentName: nextName },
-      'Global agent name updated.',
-      'Failed to update agent name.'
-    )
-  }
-
-  const handleModelChange = async (value: string) => {
-    const trimmed = value.trim()
-    const modelEntry = openRouterModelsData?.models?.find(model => model.name === trimmed)
-    const contextLength = modelEntry?.contextLength ?? agentSettings.modelContextLength ?? null
-    await persistAgentSettings(
-      { ...agentSettings, model: trimmed || null, modelContextLength: contextLength },
-      'Global agent model updated.',
-      'Failed to update agent model.'
-    )
-  }
-
-  const handleLoopIntervalInputChange = (value: string) => {
-    setLoopIntervalInput(value)
-    setLoopIntervalTouched(true)
-  }
-
   const handleToolCallTimeoutInputChange = (value: string) => {
     setToolCallTimeoutInput(value)
     setToolCallTimeoutTouched(true)
@@ -2002,39 +1854,6 @@ const Settings: React.FC = () => {
   const handleSubagentMaxTurnsInputChange = (value: string) => {
     setSubagentMaxTurnsInput(value)
     setSubagentMaxTurnsTouched(true)
-  }
-
-  const handleWorkDirectoryInputChange = (value: string) => {
-    setWorkDirectoryInput(value)
-    setWorkDirectoryTouched(true)
-  }
-
-  const commitWorkDirectoryChange = async (value: string) => {
-    const nextWorkDirectory = value.trim().length > 0 ? value.trim() : null
-    setWorkDirectoryTouched(false)
-    setWorkDirectoryInput(nextWorkDirectory ?? '')
-    await persistAgentSettings(
-      { ...agentSettings, workDirectory: nextWorkDirectory },
-      nextWorkDirectory ? 'Global agent work directory updated.' : 'Global agent work directory cleared.',
-      'Failed to update global agent work directory.'
-    )
-  }
-
-  const commitLoopIntervalChange = async (value: string) => {
-    const parsed = Number(value)
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      setLoopIntervalTouched(false)
-      setLoopIntervalInput(String(agentSettings.loopIntervalMs ?? 60000))
-      return
-    }
-
-    const nextInterval = Math.floor(parsed)
-    setLoopIntervalTouched(false)
-    await persistAgentSettings(
-      { ...agentSettings, loopIntervalMs: nextInterval },
-      'Loop cadence updated.',
-      'Failed to update loop cadence.'
-    )
   }
 
   const commitToolCallTimeoutChange = (value: string) => {
@@ -2095,24 +1914,6 @@ const Settings: React.FC = () => {
     }
 
     showStatus({ type: 'success', text: 'Default bash timeout updated.' })
-  }
-
-  const handleAutoResumeToggle = async () => {
-    await persistAgentSettings(
-      { ...agentSettings, autoResume: !agentSettings.autoResume },
-      'Auto-resume updated.',
-      'Failed to update auto-resume.'
-    )
-  }
-
-  const handleAgentToolToggle = async (toolName: string) => {
-    const current = agentSettings.toolAllowlist ?? []
-    const next = current.includes(toolName) ? current.filter(name => name !== toolName) : [...current, toolName]
-    await persistAgentSettings(
-      { ...agentSettings, toolAllowlist: next },
-      'Global agent tools updated.',
-      'Failed to update global agent tools.'
-    )
   }
 
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -3034,222 +2835,6 @@ const Settings: React.FC = () => {
           </section>
         )}
 
-        {/* Global Agent Settings Section */}
-        {import.meta.env.VITE_ENVIRONMENT === 'electron' && (
-          <section className='rounded-2xl border border-neutral-200 mica p-6 shadow-lg shadow-neutral-200/30 dark:border-neutral-800 dark:shadow-black/20'>
-            <div className='flex flex-col gap-1'>
-              <h2 className='text-xl font-semibold text-stone-900 dark:text-stone-100 mb-2'>Global Agent</h2>
-              <p className='text-sm text-stone-500 dark:text-stone-200'>
-                Configure the background agent loop, model, and heartbeat schedule.
-              </p>
-            </div>
-
-            <div className='mt-4 flex flex-col gap-5'>
-              <div className='flex flex-col gap-2'>
-                <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Agent Name</p>
-                <input
-                  type='text'
-                  value={agentSettings.agentName ?? ''}
-                  onChange={e => handleAgentNameChange(e.target.value)}
-                  disabled={agentSettingsLoading || agentSettingsSaving}
-                  className='w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-stone-700 dark:bg-zinc-900 dark:text-stone-100'
-                />
-              </div>
-
-              <div className='flex flex-col gap-2'>
-                <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Model (OpenRouter)</p>
-                <Select
-                  value={agentSettings.model || ''}
-                  onChange={handleModelChange}
-                  options={(openRouterModelsData?.models || []).map(model => model.name)}
-                  placeholder='Select a model...'
-                  disabled={agentSettingsLoading || agentSettingsSaving}
-                  className='max-w-full'
-                />
-                <p className='text-xs text-stone-500 dark:text-stone-400'>
-                  Non-OpenRouter models can be set later. TODO: add provider-aware context limits.
-                </p>
-              </div>
-
-              <div className='flex flex-col gap-2'>
-                <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Work Directory</p>
-                <input
-                  type='text'
-                  value={workDirectoryInput}
-                  placeholder='/path/to/project'
-                  onChange={e => handleWorkDirectoryInputChange(e.target.value)}
-                  onBlur={e => commitWorkDirectoryChange(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter') {
-                      e.currentTarget.blur()
-                    }
-                  }}
-                  disabled={agentSettingsLoading || agentSettingsSaving}
-                  className='w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-stone-700 dark:bg-zinc-900 dark:text-stone-100'
-                />
-                <p className='text-xs text-stone-500 dark:text-stone-400'>
-                  Used as the working directory root when the global agent runs local tools.
-                </p>
-              </div>
-
-              <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
-                <div>
-                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Loop Cadence (ms)</p>
-                  <p className='text-sm text-stone-500 dark:text-stone-400'>How often the agent checks its queue.</p>
-                </div>
-                <input
-                  type='number'
-                  min={1000}
-                  step={1000}
-                  value={loopIntervalInput}
-                  onChange={e => handleLoopIntervalInputChange(e.target.value)}
-                  onBlur={e => commitLoopIntervalChange(e.target.value)}
-                  onKeyDown={e => {
-                    if (e.key === 'Enter') {
-                      e.currentTarget.blur()
-                    }
-                  }}
-                  disabled={agentSettingsLoading || agentSettingsSaving}
-                  className='w-40 rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-stone-700 dark:bg-zinc-900 dark:text-stone-100'
-                />
-              </div>
-
-              <div className='flex items-center justify-between'>
-                <div>
-                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Auto Resume</p>
-                  <p className='text-sm text-stone-500 dark:text-stone-400'>
-                    Resume the global agent after app restart.
-                  </p>
-                </div>
-                <button
-                  onClick={handleAutoResumeToggle}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    agentSettings.autoResume ? 'bg-emerald-500 dark:bg-emerald-600' : 'bg-stone-300 dark:bg-stone-600'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      agentSettings.autoResume ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </div>
-
-              <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
-                <div>
-                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Daily Heartbeat Time</p>
-                  <p className='text-sm text-stone-500 dark:text-stone-400'>
-                    Uses your local time zone. Leave blank to disable.
-                  </p>
-                </div>
-                <div className='flex items-center gap-2'>
-                  <input
-                    type='time'
-                    value={agentSettings.heartbeatTime ?? ''}
-                    onChange={e => handleHeartbeatTimeChange(e.target.value)}
-                    disabled={agentSettingsLoading || agentSettingsSaving}
-                    className='rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-stone-700 dark:bg-zinc-900 dark:text-stone-100'
-                  />
-                  {agentSettings.heartbeatTime && (
-                    <Button
-                      variant='outline2'
-                      size='small'
-                      onClick={() => handleHeartbeatTimeChange('')}
-                      disabled={agentSettingsLoading || agentSettingsSaving}
-                    >
-                      Clear
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              {agentSettingsLoading && (
-                <p className='text-xs text-stone-500 dark:text-stone-400'>Loading agent settings…</p>
-              )}
-            </div>
-
-            <div className='mt-6 border-t border-stone-200 dark:border-stone-700 pt-4'>
-              <button
-                onClick={() => setAgentToolsExpanded(!agentToolsExpanded)}
-                className='w-full flex items-center justify-between text-left'
-              >
-                <div className='flex flex-col gap-1'>
-                  <h3 className='text-lg font-semibold text-stone-900 dark:text-stone-100'>Global Agent Tools</h3>
-                  <p className='text-sm text-stone-500 dark:text-stone-200'>
-                    Select which tools the global agent can call.
-                  </p>
-                </div>
-                <div className='flex items-center gap-2'>
-                  <span className='text-sm text-stone-500 dark:text-stone-400'>
-                    {agentSettings.toolAllowlist?.length || 0}/{tools.length} enabled
-                  </span>
-                  <i
-                    className={`bx bx-chevron-down text-2xl text-stone-500 dark:text-stone-400 transition-transform duration-200 ${
-                      agentToolsExpanded ? 'rotate-180' : ''
-                    }`}
-                  ></i>
-                </div>
-              </button>
-
-              <div
-                className={`transition-all duration-300 ease-in-out overflow-hidden ${
-                  agentToolsExpanded ? ' opacity-100 my-4' : 'max-h-0 opacity-0'
-                }`}
-              >
-                <div className='space-y-2'>
-                  {tools.map(tool => {
-                    const enabled = agentSettings.toolAllowlist?.includes(tool.name) ?? false
-                    return (
-                      <div
-                        key={tool.name}
-                        className={`flex items-center justify-between p-3 rounded-lg border ${
-                          tool.isCustom
-                            ? 'border-orange-300 dark:border-orange-600/50 bg-orange-50/50 dark:bg-orange-900/10'
-                            : 'border-stone-200 dark:border-stone-700 bg-stone-50/50 dark:bg-stone-800/30'
-                        }`}
-                      >
-                        <div className='flex-1 min-w-0'>
-                          <div className='flex items-center gap-2'>
-                            <span className='font-medium text-stone-800 dark:text-stone-200 truncate'>
-                              {tool.name.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())}
-                            </span>
-                            {tool.isCustom && (
-                              <span className='text-xs px-1.5 py-0.5 rounded bg-orange-100 dark:bg-orange-900/40 text-orange-600 dark:text-orange-300 flex-shrink-0'>
-                                Custom
-                              </span>
-                            )}
-                            {tool.isMcp && (
-                              <span className='text-xs px-1.5 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900/40 text-indigo-600 dark:text-indigo-300 flex-shrink-0'>
-                                MCP
-                              </span>
-                            )}
-                          </div>
-                          <p className='text-sm text-stone-500 dark:text-stone-400 truncate mt-0.5'>
-                            {tool.description}
-                          </p>
-                        </div>
-                        <button
-                          onClick={() => handleAgentToolToggle(tool.name)}
-                          disabled={agentSettingsSaving || agentSettingsLoading}
-                          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ml-3 flex-shrink-0 ${
-                            enabled ? 'bg-emerald-500 dark:bg-emerald-600' : 'bg-stone-300 dark:bg-stone-600'
-                          } ${agentSettingsSaving ? 'opacity-50 cursor-wait' : ''}`}
-                        >
-                          <span
-                            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                              enabled ? 'translate-x-6' : 'translate-x-1'
-                            }`}
-                          />
-                        </button>
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-            </div>
-          </section>
-        )}
-
                 {import.meta.env.VITE_ENVIRONMENT === 'electron' && (
           <section className='rounded-2xl border border-neutral-200 mica p-6 shadow-lg shadow-neutral-200/30 dark:border-neutral-800 dark:shadow-black/20'>
             <div className='flex flex-col gap-1'>
@@ -3260,7 +2845,60 @@ const Settings: React.FC = () => {
             </div>
 
             <div className='mt-4 flex flex-col gap-4'>
-              <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between'>
+              <div className='flex flex-col gap-2'>
+                <div>
+                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Subagent Provider</p>
+                  <p className='text-sm text-stone-500 dark:text-stone-400'>
+                    Provider used when a <code>subagent</code> tool call omits an explicit provider. Leave unset to
+                    follow the current chat provider.
+                  </p>
+                </div>
+                <Select
+                  value={subagentSettings.defaultProvider || ''}
+                  onChange={handleSubagentProviderChange}
+                  options={[
+                    { value: '', label: 'Follow current chat provider' },
+                    ...providers.providers.map(p => ({ value: p.name, label: p.name })),
+                  ]}
+                  placeholder='Follow current chat provider'
+                  disabled={providers.providers.length === 0}
+                  className='max-w-xs'
+                />
+                {providers.providers.length === 0 && (
+                  <p className='text-xs text-amber-600 dark:text-amber-400'>
+                    No providers available. Open a chat first to load providers.
+                  </p>
+                )}
+              </div>
+
+              <div className='flex flex-col gap-2 pt-2 border-t border-stone-200 dark:border-stone-700'>
+                <div>
+                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Subagent Model</p>
+                  <p className='text-sm text-stone-500 dark:text-stone-400'>
+                    Model used when a <code>subagent</code> tool call omits <code>model</code>. Leave unset to use the
+                    selected/default model for the resolved provider.
+                  </p>
+                </div>
+                <Select
+                  value={subagentSettings.defaultModel || ''}
+                  onChange={handleSubagentModelChange}
+                  options={[
+                    { value: '', label: 'Use provider selected/default model' },
+                    ...((subagentModelsData?.models || []).map(model => ({
+                      value: model.name,
+                      label: model.name,
+                    })) as any[]),
+                  ]}
+                  placeholder='Use provider selected/default model'
+                  className='max-w-xl'
+                />
+                <p className='text-xs text-stone-500 dark:text-stone-400'>
+                  Tool-call <code>model</code> arguments still override this setting. Current model list provider:{' '}
+                  <code>{subagentProviderForModels}</code>.
+                </p>
+              </div>
+
+              <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between pt-2 border-t border-stone-200 dark:border-stone-700'>
                 <div>
                   <p className='text-base font-medium text-stone-900 dark:text-stone-100'>Subagent Max Turns</p>
                   <p className='text-sm text-stone-500 dark:text-stone-400'>
@@ -3303,59 +2941,6 @@ const Settings: React.FC = () => {
                   <span
                     className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
                       subagentSettings.orchestratorEnabled ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </div>
-
-              <div className='flex items-center justify-between pt-2 border-t border-stone-200 dark:border-stone-700'>
-                <div>
-                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>
-                    Force OpenAI Provider for ChatGPT Parent
-                  </p>
-                  <p className='text-sm text-stone-500 dark:text-stone-400'>
-                    When current chat provider is <code>OpenAI (ChatGPT)</code>, subagent calls set provider to OpenAI.
-                  </p>
-                </div>
-                <button
-                  onClick={handleSubagentForceOpenAIToggle}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    subagentSettings.forceOpenAIProviderWhenChatGPTSelected
-                      ? 'bg-emerald-500 dark:bg-emerald-600'
-                      : 'bg-stone-300 dark:bg-stone-600'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      subagentSettings.forceOpenAIProviderWhenChatGPTSelected ? 'translate-x-6' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </div>
-
-              <div className='flex items-center justify-between pt-2 border-t border-stone-200 dark:border-stone-700'>
-                <div>
-                  <p className='text-base font-medium text-stone-900 dark:text-stone-100'>
-                    Default to Global Agent Model
-                  </p>
-                  <p className='text-sm text-stone-500 dark:text-stone-400'>
-                    If subagent tool call omits <code>model</code>, use Global Agent model from Settings.
-                  </p>
-                  <p className='text-xs text-stone-500 dark:text-stone-400 mt-1'>
-                    Current fallback model: <code>{subagentDefaultModelPreview}</code>
-                  </p>
-                </div>
-                <button
-                  onClick={handleSubagentUseGlobalModelToggle}
-                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                    subagentSettings.useGlobalAgentModelAsDefault
-                      ? 'bg-emerald-500 dark:bg-emerald-600'
-                      : 'bg-stone-300 dark:bg-stone-600'
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                      subagentSettings.useGlobalAgentModelAsDefault ? 'translate-x-6' : 'translate-x-1'
                     }`}
                   />
                 </button>

--- a/ygg-chat/client/ygg-chat-r/src/features/chats/subagentRuntime.ts
+++ b/ygg-chat/client/ygg-chat-r/src/features/chats/subagentRuntime.ts
@@ -1,16 +1,15 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { v4 as uuidv4 } from 'uuid'
 import type { RootState } from '../../store/store'
-import type { OperationMode, ToolDefinition } from './chatTypes'
+import type { Model, OperationMode, ToolDefinition } from './chatTypes'
 import { createStreamingRequest, environment, localApi } from '../../utils/api'
 import { isCommunityMode } from '../../config/runtimeMode'
-import { loadAgentSettings } from '../../helpers/agentSettingsStorage'
 import { getDefaultSubagentModePrompt } from '../../helpers/operationModePromptStorage'
 import {
   getSubagentEnabledTools,
   getSubagentMaxTurns,
   isOrchestratorEnabled,
-  shouldUseGlobalAgentModelForSubagentDefault,
+  loadSubagentToolSettings,
 } from '../../helpers/subagentToolSettings'
 import { getAllTools } from './toolDefinitions'
 
@@ -81,32 +80,41 @@ const resolveInheritedSubagentProvider = (
   if (slug === 'openaichatgpt' || slug === 'openai(chatgpt)') return 'openaichatgpt'
   if (slug === 'openrouter') return 'openrouter'
   if (slug === 'lmstudio') return 'lmstudio'
-  if (slug === 'zai' || slug === 'z.ai' || slug === 'glm') return 'zai'
+  if (slug === 'z.ai/glm' || slug === 'zai/glm' || slug === 'zai' || slug === 'z.ai' || slug === 'glm') return 'zai'
   if (slug === 'bedrock' || slug === 'awsbedrock' || slug === 'aws-bedrock' || slug === 'amazonbedrock' || slug === 'amazon-bedrock') return 'bedrock'
   return undefined
 }
 
-const resolveSubagentDefaults = async (
-  requestedModel: unknown,
-  callerProviderName?: string | null
-): Promise<{ model: string; provider?: SubagentInheritedProvider }> => {
-  const normalizedRequestedModel = typeof requestedModel === 'string' ? requestedModel.trim() : ''
+type ModelsCacheEntry = {
+  models?: Model[]
+  default?: Model
+  selected?: Model
+}
 
-  let defaultModel = DEFAULT_SUBAGENT_MODEL
-  if (shouldUseGlobalAgentModelForSubagentDefault()) {
-    try {
-      const agentSettings = await loadAgentSettings()
-      if (typeof agentSettings.model === 'string' && agentSettings.model.trim().length > 0) {
-        defaultModel = agentSettings.model.trim()
-      }
-    } catch (error) {
-      console.warn('[subagent] Failed to load global agent model for defaulting:', error)
-    }
-  }
+const resolveModelFromCache = (queryClient: QueryClient | null | undefined, providerName: string | null | undefined): string | null => {
+  if (!queryClient || !providerName) return null
+  const modelsData = queryClient.getQueryData<ModelsCacheEntry>(['models', providerName])
+  return modelsData?.selected?.name || modelsData?.default?.name || null
+}
+
+const resolveSubagentDefaults = (
+  requestedModel: unknown,
+  callerProviderName?: string | null,
+  queryClient?: QueryClient | null
+): { model: string; provider?: SubagentInheritedProvider } => {
+  const normalizedRequestedModel = typeof requestedModel === 'string' ? requestedModel.trim() : ''
+  const settings = loadSubagentToolSettings()
+  const configuredProvider = settings.defaultProvider?.trim() || null
+  const configuredModel = settings.defaultModel?.trim() || null
+  const providerNameForResolution = configuredProvider || callerProviderName || null
 
   return {
-    model: normalizedRequestedModel || defaultModel,
-    provider: resolveInheritedSubagentProvider(callerProviderName),
+    model:
+      normalizedRequestedModel ||
+      configuredModel ||
+      resolveModelFromCache(queryClient, providerNameForResolution) ||
+      DEFAULT_SUBAGENT_MODEL,
+    provider: resolveInheritedSubagentProvider(providerNameForResolution),
   }
 }
 
@@ -178,7 +186,7 @@ export const executeSimpleSubagentCall = async (
     throw new Error('Subagent requires a prompt')
   }
 
-  const { model: resolvedModel, provider: resolvedProvider } = await resolveSubagentDefaults(model, callerProviderName)
+  const { model: resolvedModel, provider: resolvedProvider } = resolveSubagentDefaults(model, callerProviderName)
 
   try {
     if (shouldUseCommunityLocalEphemeral()) {
@@ -477,7 +485,11 @@ export const executeSubagentCall = async (
   const streamId = context.streamId
   const state = getState()
   const callerProviderName = context.callerProvider ?? state.chat.providerState.currentProvider
-  const { model: resolvedModel, provider: resolvedProvider } = await resolveSubagentDefaults(model, callerProviderName)
+  const { model: resolvedModel, provider: resolvedProvider } = resolveSubagentDefaults(
+    model,
+    callerProviderName,
+    context.queryClient
+  )
 
   // Get filtered tool definitions for this subagent
   const subagentTools = getSubagentToolDefinitions(orchestratorMode, requestedTools)

--- a/ygg-chat/client/ygg-chat-r/src/helpers/subagentToolSettings.ts
+++ b/ygg-chat/client/ygg-chat-r/src/helpers/subagentToolSettings.ts
@@ -7,8 +7,8 @@ export const SUBAGENT_TOOL_SETTINGS_CHANGE_EVENT = 'ygg-subagent-tool-settings-c
 export interface SubagentToolSettings {
   enabledTools: string[] // Tool names enabled for subagent when orchestratorMode=false
   orchestratorEnabled: boolean // Whether subagent can use tools (orchestrator mode)
-  forceOpenAIProviderWhenChatGPTSelected: boolean // Force provider=openaichatgpt when parent chat provider is OpenAI(ChatGPT)
-  useGlobalAgentModelAsDefault: boolean // Use Global Agent model from Settings as subagent default model when tool call omits model
+  defaultProvider: string | null // Provider used by subagents; null follows the current chat provider
+  defaultModel: string | null // Model used by subagents; null follows the selected/default model for the resolved provider
   maxTurns: number // Maximum model/tool loop turns for one subagent invocation
 }
 
@@ -38,8 +38,8 @@ export const DEFAULT_SUBAGENT_TOOLS = [
 const DEFAULT_SETTINGS: SubagentToolSettings = {
   enabledTools: DEFAULT_SUBAGENT_TOOLS,
   orchestratorEnabled: true, // Subagent can use tools by default
-  forceOpenAIProviderWhenChatGPTSelected: true,
-  useGlobalAgentModelAsDefault: true,
+  defaultProvider: null,
+  defaultModel: null,
   maxTurns: DEFAULT_SUBAGENT_MAX_TURNS,
 }
 
@@ -51,12 +51,18 @@ export function loadSubagentToolSettings(): SubagentToolSettings {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (!stored) return { ...DEFAULT_SETTINGS }
     const parsed = JSON.parse(stored) as Partial<SubagentToolSettings>
+    const defaultProvider = typeof parsed.defaultProvider === 'string' && parsed.defaultProvider.trim()
+      ? parsed.defaultProvider.trim()
+      : null
+    const defaultModel = typeof parsed.defaultModel === 'string' && parsed.defaultModel.trim()
+      ? parsed.defaultModel.trim()
+      : null
+
     return {
       enabledTools: parsed.enabledTools ?? DEFAULT_SETTINGS.enabledTools,
       orchestratorEnabled: parsed.orchestratorEnabled ?? DEFAULT_SETTINGS.orchestratorEnabled,
-      forceOpenAIProviderWhenChatGPTSelected:
-        parsed.forceOpenAIProviderWhenChatGPTSelected ?? DEFAULT_SETTINGS.forceOpenAIProviderWhenChatGPTSelected,
-      useGlobalAgentModelAsDefault: parsed.useGlobalAgentModelAsDefault ?? DEFAULT_SETTINGS.useGlobalAgentModelAsDefault,
+      defaultProvider,
+      defaultModel,
       maxTurns: normalizeMaxTurns(parsed.maxTurns ?? DEFAULT_SETTINGS.maxTurns),
     }
   } catch {
@@ -122,29 +128,24 @@ export function toggleOrchestratorEnabled(): boolean {
   return settings.orchestratorEnabled
 }
 
-/**
- * Whether subagent calls should force provider=openaichatgpt when the parent provider is OpenAI(ChatGPT)
- */
-export function shouldForceSubagentOpenAIProvider(): boolean {
-  return loadSubagentToolSettings().forceOpenAIProviderWhenChatGPTSelected
+export function getSubagentDefaultProvider(): string | null {
+  return loadSubagentToolSettings().defaultProvider
 }
 
-export function setForceSubagentOpenAIProvider(enabled: boolean): void {
+export function setSubagentDefaultProvider(provider: string | null): void {
   const settings = loadSubagentToolSettings()
-  settings.forceOpenAIProviderWhenChatGPTSelected = enabled
+  settings.defaultProvider = typeof provider === 'string' && provider.trim() ? provider.trim() : null
+  settings.defaultModel = null
   saveSubagentToolSettings(settings)
 }
 
-/**
- * Whether subagent should default to Global Agent model when the tool call omits model
- */
-export function shouldUseGlobalAgentModelForSubagentDefault(): boolean {
-  return loadSubagentToolSettings().useGlobalAgentModelAsDefault
+export function getSubagentDefaultModel(): string | null {
+  return loadSubagentToolSettings().defaultModel
 }
 
-export function setUseGlobalAgentModelForSubagentDefault(enabled: boolean): void {
+export function setSubagentDefaultModel(model: string | null): void {
   const settings = loadSubagentToolSettings()
-  settings.useGlobalAgentModelAsDefault = enabled
+  settings.defaultModel = typeof model === 'string' && model.trim() ? model.trim() : null
   saveSubagentToolSettings(settings)
 }
 


### PR DESCRIPTION
- Added explicit Subagent Provider and Subagent Model selectors in Settings.tsx.
- Updated subagent settings persistence to store defaultProvider and defaultModel.
- Updated subagent runtime defaults so subagent calls no longer load the Global Agent model.
- Defaults now resolve from tool-call model → configured subagent model → selected/default model for resolved provider → hardcoded fallback.